### PR TITLE
Fixes CompatibilityAccessManager's receipt migration.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "73745542e20a348abe4092c8b4c96c223f753d1e",
-          "version": "3.5.0"
+          "revision": "1e65086790d4c0cc63712fcc6e8a1a27391223e8",
+          "version": "3.8.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "Purchases", url: "https://github.com/RevenueCat/purchases-ios.git", from: "3.1.0"),
+        .package(name: "Purchases", url: "https://github.com/RevenueCat/purchases-ios.git", from: "3.8.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/PurchasesHelper/CompatibilityAccessManager.swift
+++ b/Sources/PurchasesHelper/CompatibilityAccessManager.swift
@@ -61,7 +61,7 @@ public class CompatibilityAccessManager {
                    let _ = try? Data(contentsOf: receiptURL) {
                     self.log("Receipt data found. Syncing with Purchases..")
                     
-                    Purchases.shared.restoreTransactions { (info, error) in
+                    Purchases.shared.syncPurchases { (info, error) in
                         if error == nil {
                             self.log("Receipt synced.")
                         }


### PR DESCRIPTION
Since Purchases' restoreTransactions method may prompt for Apple ID and password as of version 3.6.0, this changes the restore method from restoreTransactions to syncPurchases (new in SDK 3.8.0). syncPurchases is silent and won't force refresh the receipt, and is useful when wanting to sync data with RevenueCat. The side effect is that the receipt may not be up-to-date, and thus may not sync all receipt data. To get the full up-to-date receipt, call restoreTransactions from a user-initiated action.