### PR TITLE
Adds support for originalPurchaseDate and improves ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ CompatibilityAccessManager.shared.register(entitlement:
 )
 
 ```
+
+##### Using original purchase date
+If you would like users who purchased before a certain date to have access to an entitlement, set a specific date where any purchase before then should have access. **Use this method in conjunction with compatible build versions.** There are edge cases where a user may purchase after your 'go-live' date, but then not have proper access due to App Store propagation times.
+
+```swift
+
+let subscriptionVersionLaunchDate = // The date your subscription version will go live
+
+CompatibilityAccessManager.shared.register(entitlement:
+    .init(entitlement: "premium_access", compatibleVersions: ["50"], orPurchasedBeforeDate: subscriptionVersionLaunchDate)
+)
+
+```
+
 ⚠️ As `CompatibilityAccessManager` is now your source of truth for entitlement access, **you should no longer check entitlements from the normal Purchases SDK.** You should only be checking entitlement access via `CompatibilityAccessManager`. You have a few options for checking if entitlements are active.
 
 If you want `CompatibilityAccessManager` to asynchronously fetch purchaserInfo and check if your entitlement is active between RevenueCat or your registered entitlements, call `entitlementIsActiveWithCompatibility`  on the shared `CompatibilityAccessManager`. This is safe to call *as often as you need*, as it relies on the Purchases SDK caching mechanisms for fetching purchaserInfo:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By calling `syncReceiptAndRegister`, you will sync a user's receipt with their R
 
 **A receipt must be synced with RevenueCat for this to work. You don't have to use .syncReceiptAndRegister, but you will need to either call syncPurchases or restoreTransactions from *Purchases* for CompatibilityAccessManager to work as expected.**
 
-###$ **🚨 Important: Your app will break in production if you don't register versions correctly! You have been warned.**
+#### **🚨 Important: Your app will break in production if you don't register versions correctly! You have been warned.**
 CompatibilityAccessManager requires the *build* versions of your app to be registered, not the versions that are displayed in the App Store. In other words, you must provide the `CFBundleVersion` values, **not** `CFBundleVersionShortString`. You can find these values for historical versions of your app in Xcode Organizer.
 
 #### Register Entitlements

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Add this repository as a Swift Package in Xcode.
 
 ### CompabilityAccessManager
 
-Many developers have paid apps that they would like to convert to subscription apps. PurchasesHelper includes `CompatibilityAccessManager` to be used as a source of truth for entitlement access. 
+Many developers have paid apps that they would like to convert to subscription apps. PurchasesHelper includes `CompatibilityAccessManager` to be used as a source of truth for entitlement access for apps that were previously paid. 
 
-The easiest way to get started is to call `syncReceiptAndRegister` on the shared instance of `CompatibilityAccessManager` after you initialize the Purchases SDK, then provide an array of entitlement names and versions. 
+The easiest way to get started is to call `syncReceiptIfNeededAndRegister` on the shared instance of `CompatibilityAccessManager` after the Purchases SDK has been configured, then provide an array of entitlement names and versions. 
 
-By calling `syncReceiptAndRegister`, you will sync a user's receipt with their RevenueCat app user ID if there hasn't been a receipt synced yet.
+By calling `syncReceiptIfNeededAndRegister`, you will sync a user's receipt with their RevenueCat app user ID if there hasn't been a receipt synced yet, which is useful for migrating customers from your paid app version to the RevenueCat version.
 
-**A receipt must be synced with RevenueCat for this to work. You don't have to use .syncReceiptAndRegister, but you will need to either call syncPurchases or restoreTransactions from *Purchases* for CompatibilityAccessManager to work as expected.**
+**A receipt must be synced with RevenueCat for this package to work. You don't have to use `syncReceiptIfNeededAndRegister`, but you will need to either call syncPurchases or restoreTransactions from *Purchases* for CompatibilityAccessManager to work as expected.**
 
 #### **🚨 Important: Your app will break in production if you don't register versions correctly! You have been warned.**
 CompatibilityAccessManager requires the *build* versions of your app to be registered, not the versions that are displayed in the App Store. In other words, you must provide the `CFBundleVersion` values, **not** `CFBundleVersionShortString`. You can find these values for historical versions of your app in Xcode Organizer.
@@ -32,13 +32,15 @@ For example, if your paid app was version 1.0 (Build 50) and your subscription u
 
 ```swift
 
-CompatibilityAccessManager.shared.syncReceiptAndRegister(entitlements: [
+// Purchases.configure(....)
+
+CompatibilityAccessManager.shared.syncReceiptIfNeededAndRegister(entitlements: [
     .init(entitlement: "premium_access", compatibleVersions: ["50"])
 ])
 
 ```
 
-If you don't want a receipt to sync on launch, or you are handling receipt syncing on your own side, you'll still need to register compatible versions. Instead of calling `syncReceiptAndRegister`, simply register an entitlement to a set of app build versions that should be granted access to your entitlement.
+If you don't want a receipt to sync on launch, or you are handling receipt syncing on your own side, you'll still need to register compatible versions. Instead of calling `syncReceiptIfNeededAndRegister`, simply register an entitlement to a set of app build versions that should be granted access to your entitlement.
 
 ```swift
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ Add this repository as a Swift Package in Xcode.
 
 Many developers have paid apps that they would like to convert to subscription apps. PurchasesHelper includes `CompatibilityAccessManager` to be used as a source of truth for entitlement access. 
 
-The easiest way to get started is to call `syncReceiptAndRegister` on the shared instance of `CompatibilityAccessManager` after you initialize the Purchases SDK and provide an array of entitlement names and versions. By calling `syncReceiptAndRegister`, you will sync a user's receipt with their RevenueCat app user ID if there hasn't been a receipt synced yet. **A receipt must be synced with RevenueCat for this to work. You don't have to use .syncReceiptAndRegister, but you will need to either call syncPurchases or restoreTransactions from *Purchases* for CompatibilityAccessManager to work as expected.**
+The easiest way to get started is to call `syncReceiptAndRegister` on the shared instance of `CompatibilityAccessManager` after you initialize the Purchases SDK, then provide an array of entitlement names and versions. 
 
-##### **🚨 Important: Your app will break in production if you don't do this correctly! You have been warned.**
+By calling `syncReceiptAndRegister`, you will sync a user's receipt with their RevenueCat app user ID if there hasn't been a receipt synced yet.
+
+**A receipt must be synced with RevenueCat for this to work. You don't have to use .syncReceiptAndRegister, but you will need to either call syncPurchases or restoreTransactions from *Purchases* for CompatibilityAccessManager to work as expected.**
+
+###$ **🚨 Important: Your app will break in production if you don't register versions correctly! You have been warned.**
 CompatibilityAccessManager requires the *build* versions of your app to be registered, not the versions that are displayed in the App Store. In other words, you must provide the `CFBundleVersion` values, **not** `CFBundleVersionShortString`. You can find these values for historical versions of your app in Xcode Organizer.
 
 #### Register Entitlements
@@ -44,7 +48,7 @@ CompatibilityAccessManager.shared.register(entitlement:
 
 ```
 
-##### Using original purchase date
+#### Using original purchase date
 If you would like users who purchased before a certain date to have access to an entitlement, set a specific date where any purchase before then should have access. **Use this method in conjunction with compatible build versions.** There are edge cases where a user may purchase after your 'go-live' date, but then not have proper access due to App Store propagation times.
 
 ```swift
@@ -56,6 +60,8 @@ CompatibilityAccessManager.shared.register(entitlement:
 )
 
 ```
+
+#### Checking Entitlement Access
 
 ⚠️ As `CompatibilityAccessManager` is now your source of truth for entitlement access, **you should no longer check entitlements from the normal Purchases SDK.** You should only be checking entitlement access via `CompatibilityAccessManager`. You have a few options for checking if entitlements are active.
 
@@ -77,7 +83,7 @@ purchaserInfo.entitlementIsActiveWithCompatibility(entitlement: "premium_access"
 
 ```
 
-##### Sandbox
+#### Sandbox
 
 In sandbox mode, the originalApplicationVersion is always '1.0'. To test different versions and how they behave, set the sandboxVersionOverride property to simulate a version number while only in sandbox mode:
 

--- a/README.md
+++ b/README.md
@@ -18,42 +18,48 @@ Add this repository as a Swift Package in Xcode.
 
 Many developers have paid apps that they would like to convert to subscription apps. PurchasesHelper includes `CompatibilityAccessManager` to be used as a source of truth for entitlement access. 
 
-The easiest way to get started is to call `configure` on the shared instance of `CompatibilityAccessManager` after you initialize the Purchases SDK and provide an array of entitlement names and versions. For example, if your paid app was version 1.0 (50) and your subscription update is 1.1 (75), register your entitlement like the following:
+The easiest way to get started is to call `syncReceiptAndRegister` on the shared instance of `CompatibilityAccessManager` after you initialize the Purchases SDK and provide an array of entitlement names and versions. By calling `syncReceiptAndRegister`, you will sync a user's receipt with their RevenueCat app user ID if there hasn't been a receipt synced yet. **A receipt must be synced with RevenueCat for this to work. You don't have to use .syncReceiptAndRegister, but you will need to either call syncPurchases or restoreTransactions from *Purchases* for CompatibilityAccessManager to work as expected.**
+
+##### **🚨 Important: Your app will break in production if you don't do this correctly! You have been warned.**
+CompatibilityAccessManager requires the *build* versions of your app to be registered, not the versions that are displayed in the App Store. In other words, you must provide the `CFBundleVersion` values, **not** `CFBundleVersionShortString`. You can find these values for historical versions of your app in Xcode Organizer.
+
+#### Register Entitlements
+For example, if your paid app was version 1.0 (Build 50) and your subscription update is 1.1 (Build 75), register your entitlement like the following:
 
 ```swift
 
-CompatibilityAccessManager.shared.configure(entitlements: [
-    .init(entitlement: "premium_access", versions: ["50"])
+CompatibilityAccessManager.shared.syncReceiptAndRegister(entitlements: [
+    .init(entitlement: "premium_access", compatibleVersions: ["50"])
 ])
 
 ```
 
-If you don't want purchase restoration on launch, simply register an entitlement to a set of app versions that should be granted access. 
+If you don't want a receipt to sync on launch, or you are handling receipt syncing on your own side, you'll still need to register compatible versions. Instead of calling `syncReceiptAndRegister`, simply register an entitlement to a set of app build versions that should be granted access to your entitlement.
 
 ```swift
 
 CompatibilityAccessManager.shared.register(entitlement:
-    .init(entitlement: "premium_access", versions: ["50"])
+    .init(entitlement: "premium_access", compatibleVersions: ["50"])
 )
 
 ```
-As `CompatibilityAccessManager` is now your source of truth for entitlement access, you have a few options for checking if entitlements are active.
+⚠️ As `CompatibilityAccessManager` is now your source of truth for entitlement access, **you should no longer check entitlements from the normal Purchases SDK.** You should only be checking entitlement access via `CompatibilityAccessManager`. You have a few options for checking if entitlements are active.
 
-If you want `CompatibilityAccessManager` to asynchronously fetch purchaserInfo and check if your entitlement is active between RevenueCat or your registered entitlements, call `isActive`  on the shared `CompatibilityAccessManager`. This is safe to call as often as you need, as it relies on the Purchases SDK caching mechanisms for fetching purchaserInfo:
+If you want `CompatibilityAccessManager` to asynchronously fetch purchaserInfo and check if your entitlement is active between RevenueCat or your registered entitlements, call `entitlementIsActiveWithCompatibility`  on the shared `CompatibilityAccessManager`. This is safe to call *as often as you need*, as it relies on the Purchases SDK caching mechanisms for fetching purchaserInfo:
 
 ```swift
 
-CompatibilityAccessManager.shared.isActive(entitlement: "premium_access") { (isActive, purchaserInfo) in
+CompatibilityAccessManager.shared.entitlementIsActiveWithCompatibility(entitlement: "premium_access") { (isActive, purchaserInfo) in
 
 }
 
 ```
 
-Or, you can check synchronously from an instance of PurchaserInfo:
+Or, you can check synchronously from an instance of `PurchaserInfo`:
 
 ```swift
 
-purchaserInfo.isActive(entitlement: "premium_access")
+purchaserInfo.entitlementIsActiveWithCompatibility(entitlement: "premium_access")
 
 ```
 
@@ -61,6 +67,7 @@ purchaserInfo.isActive(entitlement: "premium_access")
 
 In sandbox mode, the originalApplicationVersion is always '1.0'. To test different versions and how they behave, set the sandboxVersionOverride property to simulate a version number while only in sandbox mode:
 
+**🚨 Do not ship your app in production with this property set to anything other than `nil` (the default value).**
 ```swift
 
 CompatibilityAccessManager.shared.sandboxVersionOverride = "50"
@@ -92,11 +99,18 @@ let terms = myPackage.packageTerms()
 // terms = '3 day free trial, then $24.99/year'
 ```
 
-Set `recurring` to `false` to format your terms as non-recurring, like:
+Set `isRecurring` to `false` to format your terms as non-recurring, like:
 
 ```swift
-let terms = myPackage.packageTerms(recurring: false)
+let terms = myPackage.packageTerms(isRecurring: false)
 // terms = '3 day free trial, then $24.99 for 1 year'
+```
+
+Set `includesIntroTerms` to `false` to exclude any introductory prices from the returned string, for when a user has already redeemed an introductory price:
+
+```swift
+let terms = myPackage.packageTerms(includesIntroTerms: false)
+// terms = '$24.99/year'
 ```
 
 ### Package Sorting

--- a/Sources/PurchasesHelper/CompatibilityAccessManager.swift
+++ b/Sources/PurchasesHelper/CompatibilityAccessManager.swift
@@ -41,7 +41,7 @@ public class CompatibilityAccessManager {
     /**
      Optional configuration call to set entitlement versions as well as restore transactions if a receipt is available. **IMPORTANT**: this method should be called *after* you initialize the Purchases SDK.
      */
-    public func syncReceiptAndRegister(entitlements: [BackwardsCompatibilityEntitlement], completion: ((Purchases.PurchaserInfo?) -> Void)? = nil) {
+    public func syncReceiptIfNeededAndRegister(entitlements: [BackwardsCompatibilityEntitlement], completion: ((Purchases.PurchaserInfo?) -> Void)? = nil) {
         
         entitlements.forEach { (entitlement) in
             self.register(entitlement: entitlement)
@@ -50,6 +50,8 @@ public class CompatibilityAccessManager {
         /// If we don't have an originalApplicationVersion in the Purchases SDK, and we have a receipt available, automatically restore transactions to ensure a value for originalApplicationVersion in PurchaserInfo
         
         self.log("Fetching PurchaserInfo.")
+        
+        Purchases.shared.invalidatePurchaserInfoCache()
         
         Purchases.shared.purchaserInfo { (info, error) in
             if let originalApplicationVersion = info?.originalApplicationVersionFixed {

--- a/Sources/PurchasesHelper/CompatibilityAccessManager.swift
+++ b/Sources/PurchasesHelper/CompatibilityAccessManager.swift
@@ -63,6 +63,10 @@ public class CompatibilityAccessManager {
                 self.log("Receipt already synced, originalApplicationVersion is \(originalApplicationVersion)")
 
                 completion?(info)
+            } else if let originalPurchaseDate = info?.originalPurchaseDateFixed {
+                self.log("Receipt already synced, originalPurchaseDate is \(originalPurchaseDate)")
+                
+                completion?(info)
             } else {
                 self.log("originalApplicationVersion is nil - checking for a receipt..")
                 
@@ -78,10 +82,10 @@ public class CompatibilityAccessManager {
                         completion?(info)
                     }
                 } else {
-                    self.log("No receipt data found. Call restoreTransactions manually to sign in an fetch the latest receipt.")
+                    self.log("No receipt data found. Call restoreTransactions manually to sign in an fetch the latest receipt. PurchaserInfo may not include originalApplicationVersion or originalPurchaseDate.")
                     
                     /// No receipt data - restoreTransactions will need to be called manually as it will likely require a sign-in
-                    completion?(nil)
+                    completion?(info)
                 }
             }
         }

--- a/Sources/PurchasesHelper/CompatibilityAccessManager.swift
+++ b/Sources/PurchasesHelper/CompatibilityAccessManager.swift
@@ -55,7 +55,7 @@ public class CompatibilityAccessManager {
         
         Purchases.shared.purchaserInfo { (info, error) in
             if let originalApplicationVersion = info?.originalApplicationVersionFixed {
-                self.log("originalApplicationVersion is \(originalApplicationVersion)")
+                self.log("Receipt already synced, originalApplicationVersion is \(originalApplicationVersion)")
 
                 completion?(info)
             } else {
@@ -73,7 +73,7 @@ public class CompatibilityAccessManager {
                         completion?(info)
                     }
                 } else {
-                    self.log("No receipt data found.")
+                    self.log("No receipt data found. Call restoreTransactions manually to sign in an fetch the latest receipt.")
                     
                     /// No receipt data - restoreTransactions will need to be called manually as it will likely require a sign-in
                     completion?(nil)

--- a/Sources/PurchasesHelper/CompatibilityAccessManager.swift
+++ b/Sources/PurchasesHelper/CompatibilityAccessManager.swift
@@ -35,6 +35,11 @@ public class CompatibilityAccessManager {
      Because the sandbox `originalApplicationVersion` is always '1.0', set this property to test different version numbers.
     */
     public var sandboxVersionOverride: String? = nil
+    
+    /**
+     Set this property to test different original purchase dates when providing a 'Purchased Before' date in backwards compatibility entitlements..
+     */
+    public var sandboxOriginalPurchaseDateOverride: Date? = nil
         
     fileprivate var registeredVersions: [BackwardsCompatibilityEntitlement] = []
     
@@ -166,7 +171,7 @@ extension Purchases.PurchaserInfo {
                         }
                     }
                     
-                    if let originalPurchaseDate = self.originalPurchaseDate {
+                    if let originalPurchaseDate = self.originalPurchaseDateFixed {
                         if CompatibilityAccessManager.shared.entitlementActiveInCompatibilityDate(entitlement, originalPurchaseDate: originalPurchaseDate) == true {
                             return true
                         }
@@ -185,6 +190,14 @@ extension Purchases.PurchaserInfo {
             return CompatibilityAccessManager.shared.sandboxVersionOverride ?? self.originalApplicationVersion
         } else {
             return self.originalApplicationVersion
+        }
+    }
+    
+    fileprivate var originalPurchaseDateFixed: Date? {
+        if UIApplication.isSandbox {
+            return CompatibilityAccessManager.shared.sandboxOriginalPurchaseDateOverride ?? self.originalPurchaseDate
+        } else {
+            return self.originalPurchaseDate
         }
     }
 }

--- a/Sources/PurchasesHelper/PackageExtensions.swift
+++ b/Sources/PurchasesHelper/PackageExtensions.swift
@@ -7,7 +7,13 @@
 import Purchases
 
 public extension Purchases.Package {
-    func packageTerms(recurring: Bool = true) -> String {
+    
+    /// Customer-facing payment terms for a RevenueCat package. Not localized.
+    /// - Parameter isRecurring: If the terms should be in a recurring format. `$99/year` vs `$99 for 1 year`. Defaults to `true`.
+    /// - Parameter includesIntroTerms: If the terms should include the introductory price for the product. e.g. if a user has already redeemed a free trial, passing `false` would not include the free trial terms. Defaults to `true`.
+    /// - Returns: A string with the terms of the package's product.
+    /// e.g. `1 week free trial, then $24.99/year`
+    func packageTerms(isRecurring: Bool = true, includesIntroTerms: Bool = true) -> String {
         let normalPrice = self.localizedPriceString
         
         guard self.packageType != .lifetime else {
@@ -19,12 +25,12 @@ public extension Purchases.Package {
         // - setup the normal product subscription length string
         var perTitle = "/\(packagePerTitle)".lowercased()
         
-        if recurring == false {
+        if isRecurring == false {
             perTitle = "for \(displayTitle)".lowercased()
         }
         
         // - check for an introductory discount for a package
-        if #available(iOS 11.2, *),
+        if #available(iOS 11.2, *), includesIntroTerms == true,
             let intro = self.product.introductoryPrice {
             
             // - introductory offers
@@ -45,7 +51,7 @@ public extension Purchases.Package {
                 // - pay as you go title
                 // - e.g. '$1.99 per month for 6 months, then $24.99/year'
                 let payAYGTitle = intro.periodLengthTitle(for: intro.subscriptionPeriod.unit)
-                let introPerTitle = "\(introPrice)/\(intro.subscriptionPeriod.unit.title) for \(payAYGTitle)"
+                let introPerTitle = "\(introPrice)/\(intro.subscriptionPeriod.unit.unitTitle) for \(payAYGTitle)"
                 return "\(introPerTitle), then \(normalPrice)\(perTitle)"
                 
             @unknown default:
@@ -93,7 +99,7 @@ public extension Array where Element: Purchases.Package {
 fileprivate extension SKProductSubscriptionPeriod {
     var periodLengthTitle: String {
         let isPlural = numberOfUnits != 1
-        return "\(numberOfUnits) \(unit.title)\(isPlural ? "s" : "")"
+        return "\(numberOfUnits) \(unit.unitTitle)\(isPlural ? "s" : "")"
     }
 }
 
@@ -101,13 +107,13 @@ fileprivate extension SKProductSubscriptionPeriod {
 fileprivate extension SKProductDiscount {
     func periodLengthTitle(for unit: SKProduct.PeriodUnit) -> String {
         let isPlural = numberOfPeriods != 1
-        return "\(numberOfPeriods) \(unit.title)\(isPlural ? "s" : "")"
+        return "\(numberOfPeriods) \(unit.unitTitle)\(isPlural ? "s" : "")"
     }
 }
 
 @available(iOS 11.2, *)
 fileprivate extension SKProduct.PeriodUnit {
-    var title: String {
+    var unitTitle: String {
         switch self {
         case .day:
             return "day"


### PR DESCRIPTION
### Changes

- ReadMe improved with a lot of clarity about versions, methods, etc.
- Configure method renamed to `syncReceiptIfNeededAndRegister` for clarity about the behavior
- Adds support for comparing `originalPurchaseDate` to catch most cases of older users. Set the date at which your version with subscriptions is going live, and if the user downloaded before then, CompatibilityAccessManager will grant access as expected
- `packageTerms` now supports optional intro terms (`includesIntroTerms`, e.g. if a user isn't eligible for a trial, pass `false` to get terms without the trial details)
- Logging drastically improved, there should be no confusion about what CompatibilityAccessManager is doing