### PR TITLE
Support Purchases 4.x

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Purchases",
+        "package": "RevenueCat",
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "1e65086790d4c0cc63712fcc6e8a1a27391223e8",
-          "version": "3.8.0"
+          "revision": "5b29ae406c8480aee580c371a9c8192e42c1ee0f",
+          "version": "4.12.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PurchasesHelper",
     platforms: [
-        .iOS("9.3"), .watchOS("6.2"), .macOS("11.0")
+        .iOS(.v11), .watchOS("6.2"), .macOS(.v10_13)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -16,13 +16,15 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "Purchases", url: "https://github.com/RevenueCat/purchases-ios.git", from: "3.8.0"),
+        .package(url: "https://github.com/RevenueCat/purchases-ios.git", from: "4.12.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "PurchasesHelper",
-            dependencies: ["Purchases"])
+            dependencies: [
+                .product(name: "RevenueCat", package: "purchases-ios")
+            ]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -67,21 +67,21 @@ CompatibilityAccessManager.shared.register(entitlement:
 
 ⚠️ As `CompatibilityAccessManager` is now your source of truth for entitlement access, **you should no longer check entitlements from the normal Purchases SDK.** You should only be checking entitlement access via `CompatibilityAccessManager`. You have a few options for checking if entitlements are active.
 
-If you want `CompatibilityAccessManager` to asynchronously fetch purchaserInfo and check if your entitlement is active between RevenueCat or your registered entitlements, call `entitlementIsActiveWithCompatibility`  on the shared `CompatibilityAccessManager`. This is safe to call *as often as you need*, as it relies on the Purchases SDK caching mechanisms for fetching purchaserInfo:
+If you want `CompatibilityAccessManager` to asynchronously fetch CustomerInfo and check if your entitlement is active between RevenueCat or your registered entitlements, call `entitlementIsActiveWithCompatibility`  on the shared `CompatibilityAccessManager`. This is safe to call *as often as you need*, as it relies on the Purchases SDK caching mechanisms for fetching CustomerInfo:
 
 ```swift
 
-CompatibilityAccessManager.shared.entitlementIsActiveWithCompatibility(entitlement: "premium_access") { (isActive, purchaserInfo) in
+CompatibilityAccessManager.shared.entitlementIsActiveWithCompatibility(entitlement: "premium_access") { (isActive, customerInfo) in
 
 }
 
 ```
 
-Or, you can check synchronously from an instance of `PurchaserInfo`:
+Or, you can check synchronously from an instance of `CustomerInfo`:
 
 ```swift
 
-purchaserInfo.entitlementIsActiveWithCompatibility(entitlement: "premium_access")
+customerInfo.entitlementIsActiveWithCompatibility(entitlement: "premium_access")
 
 ```
 


### PR DESCRIPTION
Adds support for API changes in Purchases 4.x.

- `PurchaserInfo` -> `CustomerInfo`
- Updates Package extensions to use new `StoreProduct` and `SubscriptionPeriod` properties
- Fixes macOS support